### PR TITLE
Add "Rhino: Low-latency Key-value Database in Rust" to the talks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Production:
 - [Markus Pilman (Snowflake) - FoundationDB at Snowflake: Architecture and Internals (2021)](https://www.youtube.com/watch?v=4yH4r8ZCt8M)
 - [Operating FoundationDB on Kubernetes - Johannes M. Scheuermann (DoK Day EU 2022)](https://www.youtube.com/watch?v=Kf3kquvuing)
 - [How we cook Foundation DB / Daniil Gitelson (OW Service) (HighLoad++ Armenia 2022)](https://www.youtube.com/watch?v=n3DJwT21qno)
+- [Rhino: Low-latency Key-value Database in Rust (2024)](https://youtu.be/9B_v6CDFf-Y?si=ypzI76ASj0aTQElU) ([Github repo](https://github.com/laplab/rhino))
 
 ### Podcasts
 


### PR DESCRIPTION
Hello,

This is a proposal to add "Rhino: Low-latency Key-value Database in Rust" talk from RustLab 2024. Full disclosure: this talk was presented by me and I'm the main maintainer of Rhino. Rhino is built on top of FoundationDB and the talk goes into some details on how FoundationDB is used to store tables and queues.

Let me know if that makes sense!